### PR TITLE
Allow specifying cipher suites instead of single ciphers.

### DIFF
--- a/src/Cedar/Admin.c
+++ b/src/Cedar/Admin.c
@@ -8280,14 +8280,7 @@ UINT StSetServerCipher(ADMIN *a, RPC_STR *t)
 
 	StrUpper(t->String);
 
-	if (CheckCipherListName(t->String) == false)
-	{
-		return ERR_CIPHER_NOT_SUPPORTED;
-	}
-	else
-	{
-		ALog(a, NULL, "LA_SET_SERVER_CIPHER", t->String);
-	}
+	ALog(a, NULL, "LA_SET_SERVER_CIPHER", t->String);
 
 	Lock(c->lock);
 	{

--- a/src/Cedar/Server.c
+++ b/src/Cedar/Server.c
@@ -6047,10 +6047,7 @@ void SiLoadServerCfg(SERVER *s, FOLDER *f)
 		if (CfgGetStr(f, "CipherName", tmp, sizeof(tmp)))
 		{
 			StrUpper(tmp);
-			if (CheckCipherListName(tmp))
-			{
-				SetCedarCipherList(c, tmp);
-			}
+			SetCedarCipherList(c, tmp);
 		}
 
 		// Traffic information

--- a/src/Cedar/Server.h
+++ b/src/Cedar/Server.h
@@ -129,7 +129,9 @@
 #define	SERVER_DEF_PORTS_INCLIENT_DYN_MAX	1999
 
 extern char *SERVER_CONFIG_FILE_NAME;
-#define	SERVER_DEFAULT_CIPHER_NAME		"RC4-MD5"
+// This is set to an invalid OpenSSL cipher specification by default.
+// The server will default to a list of sane and secure modern ciphers.
+#define	SERVER_DEFAULT_CIPHER_NAME		"~DEFAULT~"
 #define	SERVER_DEFAULT_CERT_DAYS		(365 * 10)
 #define	SERVER_DEFAULT_HUB_NAME			"DEFAULT"
 #define	SERVER_DEFAULT_BRIDGE_NAME		"BRIDGE"

--- a/src/Mayaqua/Network.c
+++ b/src/Mayaqua/Network.c
@@ -11134,27 +11134,6 @@ void FreeWaitThread()
 	WaitThreadList = NULL;
 }
 
-// Check the cipher list name
-bool CheckCipherListName(char *name)
-{
-	UINT i;
-	// Validate arguments
-	if (name == NULL)
-	{
-		return false;
-	}
-
-	for (i = 0;i < cipher_list_token->NumTokens;i++)
-	{
-		if (StrCmpi(cipher_list_token->Token[i], name) == 0)
-		{
-			return true;
-		}
-	}
-
-	return false;
-}
-
 // Renewing the IP address of the DHCP server
 void RenewDhcp()
 {
@@ -12783,12 +12762,7 @@ void SetWantToUseCipher(SOCK *sock, char *name)
 		Free(sock->WaitToUseCipher);
 	}
 
-	Zero(tmp, sizeof(tmp));
-	StrCpy(tmp, sizeof(tmp), name);
-	StrCat(tmp, sizeof(tmp), " ");
-	StrCat(tmp, sizeof(tmp), cipher_list);
-
-	sock->WaitToUseCipher = CopyStr(tmp);
+	sock->WaitToUseCipher = CopyStr(name);
 }
 
 // Add all the chain certificates in the chain_certs directory
@@ -13062,7 +13036,8 @@ bool StartSSLEx(SOCK *sock, X *x, K *priv, bool client_tls, UINT ssl_timeout, ch
 		// Set the cipher algorithm name to want to use
 		Lock(openssl_lock);
 		{
-			SSL_set_cipher_list(sock->ssl, sock->WaitToUseCipher);
+			if (SSL_set_cipher_list(sock->ssl, sock->WaitToUseCipher) == 0)
+				SSL_set_cipher_list(sock->ssl, DEFAULT_CIPHER_LIST);
 		}
 		Unlock(openssl_lock);
 	}

--- a/src/Mayaqua/Network.h
+++ b/src/Mayaqua/Network.h
@@ -153,6 +153,7 @@ struct DYN_VALUE
 #define	DEFAULT_GETIP_THREAD_MAX_NUM		64
 #endif	// USE_STRATEGY_LOW_MEMORY
 
+#define	DEFAULT_CIPHER_LIST			"ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20:ECDHE+AES256:DHE+AES256:RSA+AES"
 
 // SSL logging function
 //#define	ENABLE_SSL_LOGGING
@@ -1379,7 +1380,6 @@ void RenewDhcp();
 void AcceptInit(SOCK *s);
 void AcceptInitEx(SOCK *s, bool no_lookup_hostname);
 void DisableGetHostNameWhenAcceptInit();
-bool CheckCipherListName(char *name);
 TOKEN_LIST *GetCipherList();
 COUNTER *GetNumTcpConnectionsCounter();
 void InitWaitThread();


### PR DESCRIPTION
CipherName now specifies all cipher suites instead of the
preferred cipher. This allows insecure ciphers like RC4 to
be permanently disabled, instead of being the default fallback
when the preferred cipher is unsupported.

CipherName is now left for OpenSSL to verify. Should it be
invalid, a secure default is used. The default CipherName setting
for new servers is one such invalid string: "~DEFAULT~". This
allows for future updates to change the default and the servers
can stay secure.

Changes proposed in this pull request:
 - 
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

-
