### PR TITLE
Peer info optional in OvsParseKeyMethod2()

### DIFF
--- a/src/Cedar/Interop_OpenVPN.c
+++ b/src/Cedar/Interop_OpenVPN.c
@@ -1151,14 +1151,17 @@ UINT OvsParseKeyMethod2(OPENVPN_KEY_METHOD_2 *ret, UCHAR *data, UINT size, bool 
 					// Random2
 					if (ReadBuf(b, ret->Random2, sizeof(ret->Random2)) == sizeof(ret->Random2))
 					{
-						// String
-						if (OvsReadStringFromBuf(b, ret->OptionString, sizeof(ret->OptionString)) &&
-							OvsReadStringFromBuf(b, ret->Username, sizeof(ret->Username)) &&
-							OvsReadStringFromBuf(b, ret->Password, sizeof(ret->Password)) &&
-							OvsReadStringFromBuf(b, ret->PeerInfo, sizeof(ret->PeerInfo)))
-						{
-							read_size = b->Current;
-						}
+                        // String
+                        if (OvsReadStringFromBuf(b, ret->OptionString, sizeof(ret->OptionString)) &&
+                            OvsReadStringFromBuf(b, ret->Username, sizeof(ret->Username)) &&
+                            OvsReadStringFromBuf(b, ret->Password, sizeof(ret->Password)))
+                        {
+                            if (!OvsReadStringFromBuf(b, ret->PeerInfo, sizeof(ret->PeerInfo)))
+                            {
+                                Zero(ret->PeerInfo, sizeof(ret->PeerInfo));
+                            }
+                            read_size = b->Current;
+                        }
 					}
 				}
 			}


### PR DESCRIPTION
Some OpenVPN clients (MikroTik router for example) do not send the peer info along with the key exchange. This patch makes the peer info string optional on the SoftEtherVPN side.

Changes proposed in this pull request:
 - 
 - 
 - 

Your great patch is much appreciated. We are considering to apply your patch into the SoftEther VPN main tree.

SoftEther VPN Patch Acceptance Policy:
http://www.softether.org/5-download/src/9.patch

You have two options which are described on the above policy.
Could you please choose either option 1 or 2, and specify it clearly on the reply?

-
